### PR TITLE
Feat allmembers

### DIFF
--- a/backend/members/urls.py
+++ b/backend/members/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path, include
 from .views_registration import register_member
 from .views_checkin import checkin
-from .views_list import list_all_members, list_indoor_members, list_outdoor_members
+from .views_list import list_all_members, list_indoor_members, list_outdoor_members, MembersSummaryView
 from rest_framework.routers import DefaultRouter
 
 
@@ -9,6 +9,9 @@ router = DefaultRouter()
 
 urlpatterns = [
     path("", include(router.urls)),
+    # Dashboard-style summary endpoint (following dashboard pattern)
+    path("summary/", MembersSummaryView.as_view(), name="members-summary"),
+    # Existing list endpoints (hybrid functionality)
     path("all/", list_all_members, name="list-all-members"),
     path("indoor/", list_indoor_members, name="list-indoor-members"),
     path("outdoor/", list_outdoor_members, name="list-outdoor-members"),

--- a/frontend/src/services/memberService.js
+++ b/frontend/src/services/memberService.js
@@ -1,6 +1,34 @@
 import apiClient, { API_ENDPOINTS } from '../config/api';
 
 export const memberService = {
+  // Get members summary stats (fast, lightweight - following dashboard pattern)
+  getSummary: async () => {
+    try {
+      const response = await apiClient.get('/summary/');
+      return {
+        success: true,
+        stats: response.data
+      };
+    } catch (error) {
+      throw new Error(error.response?.data?.message || 'Failed to fetch members summary');
+    }
+  },
+
+  // Get stats only from hybrid endpoint
+  getStatsOnly: async () => {
+    try {
+      const response = await apiClient.get(API_ENDPOINTS.members.list, {
+        params: { stats: 'true' }
+      });
+      return {
+        success: true,
+        stats: response.data
+      };
+    } catch (error) {
+      throw new Error(error.response?.data?.message || 'Failed to fetch members stats');
+    }
+  },
+
   // Get all members with pagination
   getMembers: async (params = {}) => {
     try {


### PR DESCRIPTION
This pull request introduces a dashboard-style summary API and refactors both backend and frontend to provide fast, lightweight member statistics for UI cards and dashboards. The main changes include new service functions to aggregate member stats, a dedicated summary endpoint, and frontend adjustments to load and display these stats efficiently, separating stats loading from paginated member data.

**Backend: Dashboard Statistics & API**

* Added multiple service functions in `backend/members/services.py` to aggregate member statistics, membership breakdowns, payment status, recent activity, and alerts, all following the dashboard pattern.
* Introduced a new summary endpoint `/summary/` in `backend/members/urls.py`, handled by the new `MembersSummaryView` class in `backend/members/views_list.py`, which returns essential member statistics with authentication. [[1]](diffhunk://#diff-42fe72e977ea35e385b12e4db415fce9492e55ee85d9d6c0ee02cdd90146506cL4-R14) [[2]](diffhunk://#diff-de61018030ee5420ed4e326a72313676e30f5fc0743d5a2976cac4ee49aa5cd8R3-R30)
* Updated the `list_all_members` endpoint to support a `stats=true` query parameter for returning summary stats only, and to always include summary stats in paginated responses for dashboard-style UIs. [[1]](diffhunk://#diff-de61018030ee5420ed4e326a72313676e30f5fc0743d5a2976cac4ee49aa5cd8L131-R175) [[2]](diffhunk://#diff-de61018030ee5420ed4e326a72313676e30f5fc0743d5a2976cac4ee49aa5cd8R184-R189)

**Frontend: Stats Loading & State Management**

* Refactored `frontend/src/pages/Members/index.jsx` to load summary stats via a new API call before fetching member data, storing stats in a dedicated state and ensuring the UI uses the summary endpoint for accurate, fast dashboard numbers. [[1]](diffhunk://#diff-679bfeabefe8fc7a7e504f1f7e95424e85066f5507826a74f3951762acfd85aeL74-R115) [[2]](diffhunk://#diff-679bfeabefe8fc7a7e504f1f7e95424e85066f5507826a74f3951762acfd85aeL86-R150)
* Removed estimation logic for stats from paginated member samples, ensuring all stats come from the backend summary for consistency and performance.

**Frontend: API Service Layer**

* Added `getSummary` and `getStatsOnly` methods to `frontend/src/services/memberService.js` for fetching member summary statistics from the new backend endpoints, following the dashboard data loading pattern.